### PR TITLE
Added a lot of features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-./vscode
-doxy_readme.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+./vscode
+doxy_readme.md

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # CamGetter
 
-This module is used to get images from a USB camera. This is a fork of a [this repository](https://github.com/friedy10/cam)
+Get images from a USB camera.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# cam
-Get images from a USB camera.
+# CamGetter
+
+This module is used to get images from a USB camera. This is a fork of a [this repository](https://github.com/friedy10/cam)

--- a/cam.h
+++ b/cam.h
@@ -57,15 +57,17 @@ void set_img_format(ImageGetter * g)
 {
 	// Set Image format
 	g->imageFormat.type				   = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-	g->imageFormat.fmt.pix.width	   = 1024;
-	g->imageFormat.fmt.pix.height	   = 1024;
-	g->imageFormat.fmt.pix.pixelformat = V4L2_PIX_FMT_MJPEG;
+	g->imageFormat.fmt.pix.width	   = 640;
+	g->imageFormat.fmt.pix.height	   = 480;
+	g->imageFormat.fmt.pix.pixelformat = V4L2_PIX_FMT_JPEG;//V4L2_PIX_FMT_MJPEG;
 	g->imageFormat.fmt.pix.field	   = V4L2_FIELD_NONE;
 	// tell the device you are using this format
-	if (ioctl(g->fd, VIDIOC_S_FMT, &g->imageFormat) < 0) {
+	int ret = 0;
+	if (ret = ioctl(g->fd, VIDIOC_S_FMT, &g->imageFormat) < 0) {
 		perror("Device could not set format, VIDIOC_S_FMT");
 		//exit(1);
 	}
+	cout << "Set img format resulted with: " << ret << endl; 
 }
 
 void 

--- a/cam.h
+++ b/cam.h
@@ -262,11 +262,12 @@ int save_buffer_as_array(char *buffer, size_t buffer_size, const std::string& fi
     return 0;
 }
 
-void PrepareCamera(ImageGetter* g, std::string dev){
+int PrepareCamera(ImageGetter* g, std::string dev){
     initialize_imget(g, dev.c_str());
     set_img_format(g);
 	setup_buffers(g);
 	pre_grab_frame(g);
+	return 0;
 }
 
 #endif

--- a/cam.h
+++ b/cam.h
@@ -1,5 +1,9 @@
 // Copyright (c) 2021, Friedrich Doku
-
+/*
+SONY IMX335 CMOS, It supports the below resolution & frame rate:
+MJPG: 2592x1944@30fps; 2048x1536@20fps; 1920x1080@30fps; 1280x960@30fps; 1280x720@30fps; 1024x768@30fps; 800x600@30fps; 640x480@30fps; 320x240@30fps; 160x120@30fps; 
+YUY2: 2592x1944@2fps; 2048x1536@3fps; 1920x1080@3fps; 1280x960@8fps; 1280x720@8fps; 960x540@15fps; 800x600@20fps; 640x480@30fps; 
+*/
 #ifndef CAM_H
 #define CAM_H
 
@@ -20,8 +24,21 @@
 #include <string>
 #include <string.h>
 #include <cstring>
+#include <map>
 
 using namespace std;
+
+struct Resolution {
+    int width;
+    int height;
+};
+
+std::map<std::string, Resolution> resolutions = {
+    {"VGA", {640, 480}},
+    {"XGA", {1024, 768}},
+    {"WXGAPlus", {2592, 1944}},
+    {"FullHD", {1920, 1080}}
+};
 
 typedef struct {
 	int					fd;				// File descriptor
@@ -53,12 +70,12 @@ void initialize_imget(ImageGetter * g, const char * device)
 	}
 }
 
-void set_img_format(ImageGetter * g)
+void set_img_format(ImageGetter * g, const Resolution& res)
 {
 	// Set Image format
 	g->imageFormat.type				   = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-	g->imageFormat.fmt.pix.width	   = 640;
-	g->imageFormat.fmt.pix.height	   = 480;
+	g->imageFormat.fmt.pix.width	   = res.width;
+	g->imageFormat.fmt.pix.height	   = res.height;
 	g->imageFormat.fmt.pix.pixelformat = V4L2_PIX_FMT_JPEG;//V4L2_PIX_FMT_MJPEG;
 	g->imageFormat.fmt.pix.field	   = V4L2_FIELD_NONE;
 	// tell the device you are using this format
@@ -264,7 +281,7 @@ int save_buffer_as_array(char *buffer, size_t buffer_size, const std::string& fi
 
 int PrepareCamera(ImageGetter* g, std::string dev){
     initialize_imget(g, dev.c_str());
-    set_img_format(g);
+    set_img_format(g, resolutions["WXGAPlus"]);
 	setup_buffers(g);
 	pre_grab_frame(g);
 	return 0;

--- a/cam.h
+++ b/cam.h
@@ -139,5 +139,27 @@ grab_frame(ImageGetter * g)
 	return 0;
 }
 
+int save_buffer(char *buffer, size_t buffer_size, const char *filename)
+{
+    FILE *fp = fopen(filename, "wb");
+    if (!fp) {
+        perror("Could not open file");
+        return -1;
+    }
+
+    if (fwrite(buffer, buffer_size, 1, fp) != 1) {
+        perror("Could not write buffer to file");
+        fclose(fp);
+        return -1;
+    }
+
+    fclose(fp);
+
+    printf("Buffer saved to %s\n", filename);
+
+    return 0;
+}
+
+
 #endif
 

--- a/cam.h
+++ b/cam.h
@@ -15,7 +15,11 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
+#include <fstream>
+#include <iostream>
+#include <string>
 #include <string.h>
+
 
 
 typedef struct {
@@ -139,27 +143,22 @@ grab_frame(ImageGetter * g)
 	return 0;
 }
 
-int save_buffer(char *buffer, size_t buffer_size, const char *filename)
-{
-    FILE *fp = fopen(filename, "wb");
-    if (!fp) {
-        perror("Could not open file");
+int save_buffer(char *buffer, size_t buffer_size, const std::string& filename) {
+    std::ofstream ofs(filename, std::ios::binary);
+    if (!ofs) {
+        std::cerr << "Could not open file: " << filename << std::endl;
         return -1;
     }
 
-    if (fwrite(buffer, buffer_size, 1, fp) != 1) {
-        perror("Could not write buffer to file");
-        fclose(fp);
+    if (!ofs.write(buffer, buffer_size)) {
+        std::cerr << "Could not write buffer to file: " << filename << std::endl;
         return -1;
     }
 
-    fclose(fp);
-
-    printf("Buffer saved to %s\n", filename);
+    std::cout << "Buffer saved to " << filename << std::endl;
 
     return 0;
 }
-
 
 #endif
 

--- a/cam.h
+++ b/cam.h
@@ -227,6 +227,38 @@ int save_buffer(char *buffer, size_t buffer_size, const std::string& filename) {
 
     return 0;
 }
+int save_buffer_as_array(char *buffer, size_t buffer_size, const std::string& filename, int width, int height, int bytes_per_pixel) {
+    std::ofstream ofs(filename, std::ios::binary);
+    if (!ofs) {
+        std::cerr << "Could not open file: " << filename << std::endl;
+        return -1;
+    }
+
+    // Calculate the number of bytes per row
+    int bytes_per_row = width * bytes_per_pixel;
+
+    // Create a 2D byte array of the appropriate size
+    std::vector<std::vector<unsigned char>> image_data(height, std::vector<unsigned char>(width));
+
+    // Copy the image data into the 2D array
+	cout << "Copying bytes..." << endl;
+    int buffer_index = 0;
+    for (int row = 0; row < height; row++) {
+        for (int col = 0; col < bytes_per_row; col++) {
+            image_data[row][col] = buffer[buffer_index++];
+        }
+    }
+    cout << "Writing bytes into the file..." << endl;
+    // Write the 2D byte array to file
+	
+    for (int row = 0; row < height; row++) {
+        ofs.write(reinterpret_cast<char*>(image_data[row].data()), bytes_per_row);
+    }
+
+    std::cout << "Buffer saved to " << filename << std::endl;
+
+    return 0;
+}
 
 void PrepareCamera(ImageGetter* g, std::string dev){
     initialize_imget(g, dev.c_str());

--- a/cam.h
+++ b/cam.h
@@ -32,8 +32,7 @@ typedef struct {
 	char *				buffer;
 } ImageGetter;
 
-void 
-initialize_imget(ImageGetter * g, const char * device)
+void initialize_imget(ImageGetter * g, const char * device)
 {
 	//TODO: Make it so a device can be chosen
 	g->fd = open(device, O_RDWR);
@@ -54,8 +53,7 @@ initialize_imget(ImageGetter * g, const char * device)
 	}
 }
 
-void 
-set_img_format(ImageGetter * g)
+void set_img_format(ImageGetter * g)
 {
 	// Set Image format
 	g->imageFormat.type				   = V4L2_BUF_TYPE_VIDEO_CAPTURE;
@@ -95,8 +93,7 @@ setup_buffers(ImageGetter * g)
 	}
 }
 
-int 
-grab_frame(ImageGetter * g)
+int grab_frame(ImageGetter * g)
 {
 	// mmap() will map the memory address of the device to an address in memory
 	g->buffer = (char *)mmap(NULL, g->queryBuffer.length, PROT_READ | PROT_WRITE, MAP_SHARED, g->fd, g->queryBuffer.m.offset);

--- a/cam.h
+++ b/cam.h
@@ -50,10 +50,11 @@ typedef struct {
 	char * buffer;
 } ImageGetter;
 
-void initialize_imget(ImageGetter * g, const char * device)
+void initialize_imget(ImageGetter * g, std::string device)//const char * device)
 {
+	
 	//TODO: Make it so a device can be chosen
-	g->fd = open(device, O_RDWR);
+	g->fd = open(device.c_str(), O_RDWR);
 	if (g->fd < 0) {
 		perror("Failed to open device, OPEN");
 		//exit(1);
@@ -67,8 +68,14 @@ void initialize_imget(ImageGetter * g, const char * device)
 			// something went wrong... exit
 			perror("Failed to get device capabilities, VIDIOC_QUERYCAP");
 			exit(1);
-		}
+		}		
+		printf("Driver: %s\n", capability.driver);
+		printf("Card: %s\n", capability.card);
+		printf("Bus info: %s\n", capability.bus_info);
+		printf("Version: %d.%d.%d\n", (capability.version >> 16) & 0xFF, (capability.version >> 8) & 0xFF, capability.version & 0xFF);
+		printf("Capabilities: 0x%08X\n", capability.capabilities);
 	}
+
 }
 
 void set_img_format(ImageGetter * g, const Resolution& res)

--- a/cam.h
+++ b/cam.h
@@ -47,7 +47,7 @@ typedef struct {
 	struct v4l2_requestbuffers requestBuffer;
 	struct v4l2_buffer			queryBuffer;
 	struct v4l2_buffer			bufferinfo;
-	char *				buffer;
+	char * buffer;
 } ImageGetter;
 
 void initialize_imget(ImageGetter * g, const char * device)
@@ -71,58 +71,6 @@ void initialize_imget(ImageGetter * g, const char * device)
 	}
 }
 
-bool is_control_supported(ImageGetter * g, __u32 controlId) {
-    struct v4l2_queryctrl queryControl;
-    queryControl.id = controlId;
-
-    if (ioctl(g->fd, VIDIOC_QUERYCTRL, &queryControl) == -1) {
-        // failed to query control, handle error
-        return false;
-    }
-
-    if (queryControl.flags & V4L2_CTRL_FLAG_DISABLED) {
-        // control is disabled, not supported
-        return false;
-    }
-
-    // control is supported
-    return true;
-}
-
-void check_camera_capabilities(ImageGetter * g, const char * device) {
-    g->fd = open(device, O_RDWR);
-    if (g->fd == -1) {
-        perror("Failed to open device");
-        return;
-    }
-
-    std::vector<__u32> controlIds = {
-        V4L2_CID_BRIGHTNESS,
-        V4L2_CID_CONTRAST,
-        V4L2_CID_SATURATION,
-        V4L2_CID_HUE,
-        V4L2_CID_AUTO_WHITE_BALANCE,
-		V4L2_CID_DO_WHITE_BALANCE,
-        V4L2_CID_GAMMA,
-        V4L2_CID_GAIN,
-        V4L2_CID_POWER_LINE_FREQUENCY,
-        V4L2_CID_WHITE_BALANCE_TEMPERATURE,
-        V4L2_CID_SHARPNESS,
-        V4L2_CID_BACKLIGHT_COMPENSATION,
-        V4L2_CID_EXPOSURE_AUTO
-    };
-
-    for (const auto& controlId : controlIds) {
-        if (is_control_supported(g, controlId)) {
-            std::cout << "Control " << std::hex << controlId << " is supported" << std::endl;
-        } else {
-            std::cout << "Control " << std::hex << controlId << " is not supported" << std::endl;
-        }
-    }
-
-    close(g->fd);
-}
-
 void set_img_format(ImageGetter * g, const Resolution& res)
 {
 	// Set Image format
@@ -140,16 +88,6 @@ void set_img_format(ImageGetter * g, const Resolution& res)
 	cout << "Set img format resulted with: " << ret << endl; 
 }
 
-void set_camera_control(ImageGetter * g, __u32 controlId, __s32 value) {
-    struct v4l2_control control;
-    control.id = controlId;
-    control.value = value;
-    
-    if (ioctl(g->fd, VIDIOC_S_CTRL, &control) == -1) {
-        perror("Failed to set camera control");
-        // handle error
-    }
-}
 
 
 void 

--- a/cam.h
+++ b/cam.h
@@ -96,10 +96,13 @@ setup_buffers(ImageGetter * g)
 int grab_frame(ImageGetter * g)
 {
 	// mmap() will map the memory address of the device to an address in memory
+	cout << "mapping memory addr" << endl;
 	g->buffer = (char *)mmap(NULL, g->queryBuffer.length, PROT_READ | PROT_WRITE, MAP_SHARED, g->fd, g->queryBuffer.m.offset);
+	cout << "setting buffer to 0" << endl;
 	memset(g->buffer, 0, g->queryBuffer.length);
 
 	// Create a new buffer type so the device knows which buffer we are talking about
+	cout << "create a new buffer" << endl;
 	g->bufferinfo;
 	memset(&g->bufferinfo, 0, sizeof(g->bufferinfo));
 	g->bufferinfo.type	 = V4L2_BUF_TYPE_VIDEO_CAPTURE;
@@ -107,7 +110,7 @@ int grab_frame(ImageGetter * g)
 	g->bufferinfo.index	 = 0;
 
 	// Activate streaming
-
+	cout << "activate streaming" << endl;
 	int type = g->bufferinfo.type;
 	if (ioctl(g->fd, VIDIOC_STREAMON, &type) < 0) {
 		perror("Could not start streaming, VIDIOC_STREAMON");
@@ -136,7 +139,7 @@ int grab_frame(ImageGetter * g)
 	printf("Buffer has: %f",(double)g->bufferinfo.bytesused / 1024);
     printf(" KBytes of data\n");
 
-	close(g->fd);
+	//close(g->fd);
 
 	return 0;
 }
@@ -158,11 +161,10 @@ int save_buffer(char *buffer, size_t buffer_size, const std::string& filename) {
     return 0;
 }
 
-ImageGetter& PrepareCamera(std::string dev){
-    static ImageGetter g;
-    initialize_imget(&g, dev.c_str());
-    set_img_format(&g);
-    return g;
+void PrepareCamera(ImageGetter* g, std::string dev){
+    initialize_imget(g, dev.c_str());
+    set_img_format(g);
+	setup_buffers(g);
 }
 
 #endif

--- a/cam.h
+++ b/cam.h
@@ -19,8 +19,9 @@
 #include <iostream>
 #include <string>
 #include <string.h>
+#include <cstring>
 
-
+using namespace std;
 
 typedef struct {
 	int					fd;				// File descriptor
@@ -32,14 +33,14 @@ typedef struct {
 } ImageGetter;
 
 void 
-initialize_imget(ImageGetter * g, char * device)
+initialize_imget(ImageGetter * g, const char * device)
 {
 	//TODO: Make it so a device can be chosen
-	g->fd = open("/dev/video0", O_RDWR);
+	g->fd = open(device, O_RDWR);
 	if (g->fd < 0) {
 		perror("Failed to open device, OPEN");
 		//exit(1);
-	}
+	} else cout << "Camera Opened!" << endl;
 
 
 	// Ask the device if it can capture frames
@@ -158,6 +159,13 @@ int save_buffer(char *buffer, size_t buffer_size, const std::string& filename) {
     std::cout << "Buffer saved to " << filename << std::endl;
 
     return 0;
+}
+
+ImageGetter& PrepareCamera(std::string dev){
+    static ImageGetter g;
+    initialize_imget(&g, dev.c_str());
+    set_img_format(&g);
+    return g;
 }
 
 #endif

--- a/capabilities.h
+++ b/capabilities.h
@@ -1,0 +1,56 @@
+#ifndef CAPABILITIES_H
+#define CAPABILITIES_H
+
+#include <linux/videodev2.h>
+#include <string>
+#include <unordered_map>
+#include <iostream>
+
+void printCapabilities(const v4l2_capability& cap) {
+    std::unordered_map<int, std::string> capabilityMap = {
+        {V4L2_CAP_VIDEO_CAPTURE, "Video Capture"},
+        {V4L2_CAP_VIDEO_OUTPUT, "Video Output"},
+        {V4L2_CAP_VIDEO_OVERLAY, "Video Overlay"},
+        {V4L2_CAP_VBI_CAPTURE, "VBI Capture"},
+        {V4L2_CAP_VBI_OUTPUT, "VBI Output"},
+        {V4L2_CAP_SLICED_VBI_CAPTURE, "Sliced VBI Capture"},
+        {V4L2_CAP_SLICED_VBI_OUTPUT, "Sliced VBI Output"},
+        {V4L2_CAP_RDS_CAPTURE, "RDS Data Capture"},
+        {V4L2_CAP_VIDEO_OUTPUT_OVERLAY, "Video Output Overlay"},
+        {V4L2_CAP_HW_FREQ_SEEK, "Hardware Frequency Seek"},
+        {V4L2_CAP_RDS_OUTPUT, "RDS Encoder"},
+        {V4L2_CAP_VIDEO_CAPTURE_MPLANE, "Multiplanar Video Capture"},
+        {V4L2_CAP_VIDEO_OUTPUT_MPLANE, "Multiplanar Video Output"},
+        {V4L2_CAP_VIDEO_M2M_MPLANE, "Multiplanar Video Mem-to-Mem"},
+        {V4L2_CAP_VIDEO_M2M, "Video Mem-to-Mem"},
+        {V4L2_CAP_TUNER, "Tuner"},
+        {V4L2_CAP_AUDIO, "Audio"},
+        {V4L2_CAP_RADIO, "Radio Device"},
+        {V4L2_CAP_MODULATOR, "Modulator"},
+        {V4L2_CAP_SDR_CAPTURE, "SDR Capture"},
+        {V4L2_CAP_EXT_PIX_FORMAT, "Extended Pixel Format"},
+        {V4L2_CAP_SDR_OUTPUT, "SDR Output"},
+        {V4L2_CAP_META_CAPTURE, "Metadata Capture"},
+        {V4L2_CAP_READWRITE, "Read/Write System Calls"},
+        {V4L2_CAP_STREAMING, "Streaming I/O IOCTLs"},
+        {V4L2_CAP_META_OUTPUT, "Metadata Output"},
+        {V4L2_CAP_TOUCH, "Touch Device"},
+        {V4L2_CAP_IO_MC, "Input/Output Controlled by Media Controller"},
+        {V4L2_CAP_DEVICE_CAPS, "Device Capabilities"}
+    };
+
+    std::cout << "Driver: " << cap.driver << std::endl;
+    std::cout << "Card: " << cap.card << std::endl;
+    std::cout << "Bus Info: " << cap.bus_info << std::endl;
+    std::cout << "Version: " << cap.version << std::endl;
+    std::cout << "Capabilities: " << std::hex << cap.capabilities << std::endl;
+    std::cout << "Device Caps: " << std::hex << cap.device_caps << std::endl;
+
+    std::cout << "Human-readable capabilities:" << std::endl;
+    for (const auto& kv : capabilityMap) {
+        if (cap.capabilities & kv.first)
+            std::cout << "- " << kv.second << std::endl;
+    }
+}
+
+#endif

--- a/controls.hpp
+++ b/controls.hpp
@@ -114,17 +114,20 @@ inline void CamCtrl::set_camera_control(ImageGetter * g, __u32 controlId, __s32 
     control.id = controlId;
     control.value = value;
     
+    cout << "fd = " << g->fd << endl;
+    cout << "Attmept to write Control " << controlId << " value: "<< value << endl;
+
     if (ioctl(g->fd, VIDIOC_G_CTRL, &control) == -1) {
         perror("Failed to set camera control");
         cout << "ControlID: " << controlId << endl; 
         // handle error
     } else {
-        cout << "Control " << controlId << "writen sucessfully!" << endl;
+        cout << " Control " << controlId << "writen sucessfully!" << endl;
     }
 }
 
 inline void CamCtrl::set_camera_controls(ImageGetter * g, const CameraControls& controls) {
-    set_camera_control(g, 0x00980900, controls.brightness); // V4L2_CID_BRIGHTNESS
+    set_camera_control(g, V4L2_CID_BRIGHTNESS, controls.brightness);
     set_camera_control(g, V4L2_CID_CONTRAST, controls.contrast);
     set_camera_control(g, V4L2_CID_SATURATION, controls.saturation);
     set_camera_control(g, V4L2_CID_HUE, controls.hue);
@@ -150,7 +153,6 @@ inline bool CamCtrl::is_control_supported(ImageGetter * g, __u32 controlId) {
         // control is disabled, not supported
         return false;
     }
-
     cout << "Control supported!" << endl;
     return true;
 }
@@ -168,7 +170,6 @@ inline void CamCtrl::check_camera_capabilities(ImageGetter * g, const char * dev
         V4L2_CID_SATURATION,
         V4L2_CID_HUE,
         V4L2_CID_AUTO_WHITE_BALANCE,
-		V4L2_CID_DO_WHITE_BALANCE,
         V4L2_CID_GAMMA,
         V4L2_CID_GAIN,
         V4L2_CID_POWER_LINE_FREQUENCY,
@@ -177,7 +178,7 @@ inline void CamCtrl::check_camera_capabilities(ImageGetter * g, const char * dev
         V4L2_CID_BACKLIGHT_COMPENSATION,
         V4L2_CID_EXPOSURE_AUTO
     };
-
+    cout << "Checking camera capabilities for fd: " << g->fd << endl;
     for (const auto& controlId : controlIds) {
         if (is_control_supported(g, controlId)) {
             std::cout << "Control " << std::hex << controlId << " is supported" << std::endl;

--- a/controls.hpp
+++ b/controls.hpp
@@ -115,7 +115,6 @@ inline void CamCtrl::set_camera_control(ImageGetter * g, __u32 controlId, __s32 
     control.id = controlId;
     control.value = value;
     cout << "Attmept to write Control "<< std::hex  << controlId << " value: " << std::dec << value << endl;
-    // VIDIOC_S_EXT_CTRLS
     if (ioctl(g->fd, VIDIOC_S_CTRL, &control) == -1) { 
         perror("Failed to set camera control");
         cout << "ControlID: " << controlId << endl; 
@@ -127,6 +126,11 @@ inline void CamCtrl::set_camera_control(ImageGetter * g, __u32 controlId, __s32 
 
 inline void CamCtrl::set_camera_controls(ImageGetter * g, const CameraControls& controls) {
      cout << "Setting camera controls for fd: " << g->fd << endl;
+    // Stop the camera streaming
+    if (ioctl(g->fd, VIDIOC_STREAMOFF, &g->bufferinfo.type) == -1) {
+        perror("Failed to stop camera streaming");
+        return;
+    }
     set_camera_control(g, V4L2_CID_BRIGHTNESS, controls.brightness);
     set_camera_control(g, V4L2_CID_CONTRAST, controls.contrast);
     set_camera_control(g, V4L2_CID_SATURATION, controls.saturation);
@@ -140,6 +144,11 @@ inline void CamCtrl::set_camera_controls(ImageGetter * g, const CameraControls& 
     set_camera_control(g, V4L2_CID_BACKLIGHT_COMPENSATION, controls.backlightCompensation);
     set_camera_control(g, V4L2_CID_EXPOSURE_AUTO, controls.exposureAuto);
     set_camera_control(g, V4L2_CID_EXPOSURE_ABSOLUTE, controls.exposureTimeAbsolute);
+    // Start the camera streaming again
+    if (ioctl(g->fd, VIDIOC_STREAMON, &g->bufferinfo.type) == -1) {
+        perror("Failed to start camera streaming");
+        return;
+    }
 }
 inline bool CamCtrl::is_control_supported(ImageGetter * g, __u32 controlId) {
     struct v4l2_queryctrl queryControl;

--- a/controls.hpp
+++ b/controls.hpp
@@ -1,0 +1,193 @@
+#ifndef CONTROLS_HPP
+#define CONTROLS_HPP
+
+#include <fstream>
+#include <iostream>
+#include <filesystem>
+#include <jsoncpp/json/json.h>
+
+#include "cam.h"
+
+// v4l2-ctl -d /dev/video1 -l // command to check cameras controls
+
+class CamCtrl
+{
+public:
+    struct CameraControls {
+        int brightness = 0;
+        int contrast = 32;
+        int saturation = 64;
+        int hue = 0;
+        int autoWhiteBalance = 1;
+        int gamma = 100;
+        int gain = 0;
+        int powerLineFrequency = 1;
+        int whiteBalanceTemperature = 4600;
+        int sharpness = 3;
+        int backlightCompensation = 1;
+        int exposureAuto = 3;
+        int exposureTimeAbsolute = 157;
+    };
+    bool create_cam_config_file(const std::string& filename, const CameraControls& controls);
+    bool read_cam_config_file(const std::string& filename, CameraControls& controls);
+    bool load_cam_config(const std::string& filename, CameraControls& controls);
+    void set_camera_control(ImageGetter * g, __u32 controlId, __s32 value);
+    void set_camera_controls(ImageGetter * g, const CameraControls& controls);
+    void check_camera_capabilities(ImageGetter * g, const char * device);
+    bool is_control_supported(ImageGetter * g, __u32 controlId);
+
+
+
+
+};
+
+inline bool CamCtrl::create_cam_config_file(const std::string& filename, const CameraControls& controls) {
+    Json::Value root;
+    root["brightness"] = controls.brightness;
+    root["contrast"] = controls.contrast;
+    root["saturation"] = controls.saturation;
+    root["hue"] = controls.hue;
+    root["autoWhiteBalance"] = controls.autoWhiteBalance;
+    root["gamma"] = controls.gamma;
+    root["gain"] = controls.gain;
+    root["powerLineFrequency"] = controls.powerLineFrequency;
+    root["whiteBalanceTemperature"] = controls.whiteBalanceTemperature;
+    root["sharpness"] = controls.sharpness;
+    root["backlightCompensation"] = controls.backlightCompensation;
+    root["exposureAuto"] = controls.exposureAuto;
+    root["exposureTimeAbsolute"] = controls.exposureTimeAbsolute;
+
+    std::ofstream configFile(filename);
+    if (configFile.is_open()) {
+        configFile << root;
+        configFile.close();
+        std::cout << "Configuration file created successfully." << std::endl;
+        return true;
+    } else {
+        std::cout << "Failed to create configuration file." << std::endl;
+        return false;
+    }
+}
+
+inline bool CamCtrl::read_cam_config_file(const std::string& filename, CameraControls& controls) {
+    std::ifstream configFile(filename);
+    if (!configFile.is_open()) {
+        std::cout << "Failed to open config file: " << filename << std::endl;
+        return false;
+    }
+
+    Json::Value configJson;
+    configFile >> configJson;
+    configFile.close();
+
+
+    controls.brightness = configJson["brightness"].asInt();
+    controls.contrast = configJson["contrast"].asInt();
+    controls.saturation = configJson["saturation"].asInt();
+    controls.hue = configJson["hue"].asInt();
+    controls.autoWhiteBalance = configJson["autoWhiteBalance"].asInt();
+    controls.gamma = configJson["gamma"].asInt();
+    controls.gain = configJson["gain"].asInt();
+    controls.powerLineFrequency = configJson["powerLineFrequency"].asInt();
+    controls.whiteBalanceTemperature = configJson["whiteBalanceTemperature"].asInt();
+    controls.sharpness = configJson["sharpness"].asInt();
+    controls.backlightCompensation = configJson["backlightCompensation"].asInt();
+    controls.exposureAuto = configJson["exposureAuto"].asInt();
+    controls.exposureTimeAbsolute = configJson["exposureTimeAbsolute"].asInt();
+
+    std::cout << "Config file successfully read: " << filename << std::endl;
+    return true;
+}
+
+inline bool CamCtrl::load_cam_config(const std::string& filename, CameraControls& controls) {
+    if (std::filesystem::exists(filename)) {
+        // Config file exists, read the parameters
+        std::cout << "Config file exists, reading params from there.." << std::endl;
+        return read_cam_config_file(filename, controls);
+    } else {
+        std::cout << "Config file doesn't exist, creating a new one with default values" << std::endl;
+        return create_cam_config_file(filename, controls);
+    }
+}
+inline void CamCtrl::set_camera_control(ImageGetter * g, __u32 controlId, __s32 value) {
+    struct v4l2_control control;
+    control.id = controlId;
+    control.value = value;
+    
+    if (ioctl(g->fd, VIDIOC_G_CTRL, &control) == -1) {
+        perror("Failed to set camera control");
+        cout << "ControlID: " << controlId << endl; 
+        // handle error
+    } else {
+        cout << "Control " << controlId << "writen sucessfully!" << endl;
+    }
+}
+
+inline void CamCtrl::set_camera_controls(ImageGetter * g, const CameraControls& controls) {
+    set_camera_control(g, 0x00980900, controls.brightness); // V4L2_CID_BRIGHTNESS
+    set_camera_control(g, V4L2_CID_CONTRAST, controls.contrast);
+    set_camera_control(g, V4L2_CID_SATURATION, controls.saturation);
+    set_camera_control(g, V4L2_CID_HUE, controls.hue);
+    set_camera_control(g, V4L2_CID_AUTO_WHITE_BALANCE, controls.autoWhiteBalance);
+    set_camera_control(g, V4L2_CID_GAMMA, controls.gamma);
+    set_camera_control(g, V4L2_CID_GAIN, controls.gain);
+    set_camera_control(g, V4L2_CID_POWER_LINE_FREQUENCY, controls.powerLineFrequency);
+    set_camera_control(g, V4L2_CID_WHITE_BALANCE_TEMPERATURE, controls.whiteBalanceTemperature);
+    set_camera_control(g, V4L2_CID_SHARPNESS, controls.sharpness);
+    set_camera_control(g, V4L2_CID_BACKLIGHT_COMPENSATION, controls.backlightCompensation);
+    set_camera_control(g, V4L2_CID_EXPOSURE_AUTO, controls.exposureAuto);
+}
+inline bool CamCtrl::is_control_supported(ImageGetter * g, __u32 controlId) {
+    struct v4l2_queryctrl queryControl;
+    queryControl.id = controlId;
+
+    if (ioctl(g->fd, VIDIOC_QUERYCTRL, &queryControl) == -1) {
+        // failed to query control, handle error
+        return false;
+    }
+
+    if (queryControl.flags & V4L2_CTRL_FLAG_DISABLED) {
+        // control is disabled, not supported
+        return false;
+    }
+
+    cout << "Control supported!" << endl;
+    return true;
+}
+
+inline void CamCtrl::check_camera_capabilities(ImageGetter * g, const char * device) {
+    g->fd = open(device, O_RDWR);
+    if (g->fd == -1) {
+        perror("Failed to open device");
+        return;
+    }
+
+    std::vector<__u32> controlIds = {
+        V4L2_CID_BRIGHTNESS,
+        V4L2_CID_CONTRAST,
+        V4L2_CID_SATURATION,
+        V4L2_CID_HUE,
+        V4L2_CID_AUTO_WHITE_BALANCE,
+		V4L2_CID_DO_WHITE_BALANCE,
+        V4L2_CID_GAMMA,
+        V4L2_CID_GAIN,
+        V4L2_CID_POWER_LINE_FREQUENCY,
+        V4L2_CID_WHITE_BALANCE_TEMPERATURE,
+        V4L2_CID_SHARPNESS,
+        V4L2_CID_BACKLIGHT_COMPENSATION,
+        V4L2_CID_EXPOSURE_AUTO
+    };
+
+    for (const auto& controlId : controlIds) {
+        if (is_control_supported(g, controlId)) {
+            std::cout << "Control " << std::hex << controlId << " is supported" << std::endl;
+        } else {
+            std::cout << "Control " << std::hex << controlId << " is not supported" << std::endl;
+        }
+    }
+
+    close(g->fd);
+}
+
+
+#endif


### PR DESCRIPTION
- Camera controls: Adds a full CamCtrl utility to read, write, and apply V4L2
camera controls on the fly (stops streaming, sets controls, restarts), including
support checks and a custom EXPOSURE_DYNAMIC_FRAMERATE CID.
- Config management: Introduces JSON-based camera control config files, with
helpers to create, read, and load settings, and auto-generate defaults by
parsing v4l2-ctl output (with a boilerplate header documenting available
controls).
- Capability introspection: Adds human-readable capability printing via
capabilities.h to interpret VIDIOC_QUERYCAP.
- Device handling: Implements camera preparation, buffer setup, streaming
control, and frame grabbing; splits grab_frame for performance and fixes save
buffer behavior.
- Resolution handling: Adds named resolution presets and parameterizes
resolution in the capture path.
- DX polish: Updates .gitignore and README; makes parsing of v4l2-ctl output
more flexible.